### PR TITLE
[FIX] saas_portal_templates:  missing attribute error

### DIFF
--- a/saas_portal_templates/controllers/main.py
+++ b/saas_portal_templates/controllers/main.py
@@ -13,7 +13,7 @@ class SaasPortalTemplates(saas_portal_controller):
         fields = ['id', 'name', 'summary']
         templates = request.env['saas_portal.plan'].sudo().search_read(domain=domain, fields=fields)
         values = {'templates': templates}
-        return request.website.render("saas_portal_templates.select_template", values)
+        return request.render("saas_portal_templates.select_template", values)
 
     @http.route(['/saas_portal_templates/new_database'], type='http', auth='public', website=True)
     def new_database(self, **post):


### PR DESCRIPTION
getting error message: "'website' object has no attribute 'render'". Let's try returning 'request.render' in place of 'request.windows.render'